### PR TITLE
fix: prevent newline processing in output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,8 +84,8 @@ exit_code=0
 if [ "$SHELLCHECK_DISABLE" != "1" ]; then
 	echo -e "Validating shell scripts files using shellcheck\n"
 	# shellcheck disable=SC2086
-	shellcheck_error="$(shellcheck $sh_files)"
-	shellcheck_code="$?"
+	shellcheck_error=$( (shellcheck $sh_files) | while read -r x; do echo "$x"; done; )
+	shellcheck_code="${PIPESTATUS[0]}"
 fi
 
 if [ "$SHFMT_DISABLE" != "1" ]; then


### PR DESCRIPTION
Fixes #15 

Problem arises due to the command expansion, `$(...)`. 

Output should match that if using `shellcheck` directly.

Confirmed using bash v5