### PR TITLE
Ignore checkbashisms false positives

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -137,7 +137,12 @@ if [ "$CHECKBASHISMS_ENABLE" == "1" ]; then
 	test "$checkbashisms_code" != "0" && {
 		echo -e "$checkbashisms_error"
 		echo -e "\nThe files above have some checkbashisms issues\n"
-		exit_code=1
+		if ((checkbashisms_code != 4)); then
+		  exit_code=1
+		else
+		  # see https://github.com/duggan/shlint/blob/0fcd979319e3f37c2cd53ccea0b51e16fda710a1/lib/checkbashisms#L489
+		  echo -e "Ignoring 'could not find any possible bashisms in bash script' issues"
+		fi
 	}
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ SHELLCHECK_DISABLE=0
 SHFMT_DISABLE=0
 SH_CHECKER_COMMENT=0
 CHECKBASHISMS_ENABLE=0
-ONLY_DIFF=1
+ONLY_DIFF=0
 
 if [ "${INPUT_SH_CHECKER_SHELLCHECK_DISABLE}" == "1" ] || [ "${INPUT_SH_CHECKER_SHELLCHECK_DISABLE}" == "true" ]; then
 	SHELLCHECK_DISABLE=1
@@ -83,7 +83,11 @@ else
 fi
 
 test "$sh_files" || {
-	echo "No shell scripts found in this repository. Make a sure that you did a checkout :)"
+	if ((ONLY_DIFF == 1)); then
+	  echo "No shell scripts were changed."
+	else
+	  echo "No shell scripts found in this repository. Make a sure that you did a checkout :)"
+	fi
 	exit 0
 }
 


### PR DESCRIPTION
This fixes checkbashisms returning error 4 when reporting `could not find any possible bashisms in bash script`. See
https://github.com/duggan/shlint/blob/0fcd979319e3f37c2cd53ccea0b51e16fda710a1/lib/checkbashisms#L489

Here's a successful run using this PR:

```
Validating 'bashisms' for shell scripts files using checkbashisms

could not find any possible bashisms in bash script ...

The files above have some checkbashisms issues

Ignoring 'could not find any possible bashisms in bash script' issues
```