### PR TITLE
Remove 'set -e' to allow checkbashisms to return error code

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 cd "$GITHUB_WORKSPACE" || exit 1
 


### PR DESCRIPTION
`set -e` causes a scriot to immediately abort if any program returns a non-zero exit code.