### PR TITLE
Add support for filenames with spaces

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,7 +66,7 @@ _show_sh_files() {
 
 _comment_on_github() {
   local content
-  read -r -d '' content <<EOF
+  IFS= read -r -d '' content <<EOF
 #### \`sh-checker report\`
 
 To get the full details, please check in the [job]("https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID") output.
@@ -131,18 +131,19 @@ if ((SHELLCHECK_DISABLE != 1)); then
   else
     # .shellcheck returns 0-4: https://github.com/koalaman/shellcheck/blob/dff8f9492a153b4ad8ac7d085136ce532e8ea081/shellcheck.hs#L191
     exit_code=$shellcheck_code
-    read -r -d '' shellcheck_error <<EOF
+    IFS= read -r -d '' shellcheck_error <<EOF
 
 'shellcheck $SHELLCHECK_OPTS' returned error $shellcheck_code finding the following syntactical issues:
------
+\-\-\-\-\-
 $shellcheck_output
------
-You can address these issues in on of three ways:\n'
-1. Manually correct the issue in the offending shell script;\n'
-2. Disable specific issues by adding the comment:\n'
-  # shellcheck disable=NNNN\n'
-above the line that contains the issue, where NNNN is the error code;\n'
+\-\-\-\-\-
+You can address these issues in on of three ways:
+1. Manually correct the issue in the offending shell script;
+2. Disable specific issues by adding the comment:
+  # shellcheck disable=NNNN
+above the line that contains the issue, where NNNN is the error code;
 3. Add '-e NNNN' to the SHELLCHECK_OPTS setting in your .yml action file.
+
 
 EOF
   fi
@@ -159,13 +160,15 @@ if ((SHFMT_DISABLE != 1)); then
   else
     # shfmt returns 0 or 1: https://github.com/mvdan/sh/blob/dbbad59b44d586c0f3d044a3820c18c41b495e2a/cmd/shfmt/main.go#L72
     ((exit_code |= 8))
-    read -r -d '' shfmt_error <<EOF
+    IFS= read -r -d '' shfmt_error <<EOF
 
 'shfmt $SHFMT_OPTS' returned error $shfmt_code finding the following formatting issues:
------
+\-\-\-\-\-
 $shfmt_output
------
+\-\-\-\-\-
+
 You can use 'shfmt $SHFMT_OPTS -w filename' to reformat each filename to meet shfmt's requirements.
+
 
 EOF
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -153,7 +153,7 @@ if ((SHFMT_DISABLE != 1)); then
   else
     # shfmt returns 0 or 1: https://github.com/mvdan/sh/blob/dbbad59b44d586c0f3d044a3820c18c41b495e2a/cmd/shfmt/main.go#L72
     ((exit_code |= 8))
-    printf "\\n'shfmt %s' returned error %d finding the following formatting issues:\\n" "$shfmt_code" "$SHFMT_OPTS"
+    printf "\\n'shfmt %s' returned error %d finding the following formatting issues:\\n" "$SHFMT_OPTS" "$shfmt_code" 
     printf '%s' "$shfmt_error"
     printf '\n'
     printf "You can use 'shfmt %s -w filename' to reformat each filename to meet shfmt's requirements.\\n" "$SHFMT_OPTS"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -134,10 +134,12 @@ if ((SHELLCHECK_DISABLE != 1)); then
     IFS= read -r -d '' shellcheck_error <<EOF
 
 'shellcheck $SHELLCHECK_OPTS' returned error $shellcheck_code finding the following syntactical issues:
-\-\-\-\-\-
+
+----------
 $shellcheck_output
-\-\-\-\-\-
-You can address these issues in on of three ways:
+----------
+
+You can address the above issues in on of three ways:
 1. Manually correct the issue in the offending shell script;
 2. Disable specific issues by adding the comment:
   # shellcheck disable=NNNN
@@ -163,12 +165,14 @@ if ((SHFMT_DISABLE != 1)); then
     IFS= read -r -d '' shfmt_error <<EOF
 
 'shfmt $SHFMT_OPTS' returned error $shfmt_code finding the following formatting issues:
-\-\-\-\-\-
+
+----------
 $shfmt_output
-\-\-\-\-\-
+----------
 
-You can use 'shfmt $SHFMT_OPTS -w filename' to reformat each filename to meet shfmt's requirements.
+You can reformat the above files to meet shfmt's requirements by typing:
 
+  shfmt $SHFMT_OPTS -w filename
 
 EOF
   fi
@@ -176,16 +180,16 @@ EOF
 fi
 
 if ((CHECKBASHISMS_ENABLE == 1)); then
-  printf 'Validating %d shell script(s) files using checkbashisms:\n' "${#sh_files[@]}"
+  printf '\n\nValidating %d shell script(s) files using checkbashisms:\n' "${#sh_files[@]}"
   checkbashisms "${sh_files[@]}"
   checkbashisms_code=$?
   if ((checkbashisms_code == 0)); then
-    printf 'checkbashisms found no issues.\n'
+    printf '\ncheckbashisms found no issues.\n'
   else
     printf '\ncheckbashisms returned error %d finding the bashisms listed above.\n' "$checkbashisms_code"
     if ((checkbashisms_code == 4)); then
       # see https://github.com/duggan/shlint/blob/0fcd979319e3f37c2cd53ccea0b51e16fda710a1/lib/checkbashisms#L489
-      printf "Ignoring 'could not find any possible bashisms in bash script' issues\\n"
+      printf "\\nIgnoring 'could not find any possible bashisms in bash script' issues\\n"
     else
       # checkbashisms returns 0-3: https://linux.die.net/man/1/checkbashisms
       ((exit_code |= (checkbashisms_code << 4)))
@@ -200,7 +204,7 @@ if ((shellcheck_code != 0 || shfmt_code != 0)); then
 fi
 
 if ((exit_code == 0)); then
-  printf 'No issues found in the %d shell script(s) scanned :)\n' "${#sh_files[@]}"
+  printf '\nNo issues found in the %d shell script(s) scanned :)\n' "${#sh_files[@]}"
 fi
 
 exit $exit_code

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,48 +1,72 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-cd "$GITHUB_WORKSPACE" || exit 1
+cd "$GITHUB_WORKSPACE" || {
+  printf 'Directory not found: "%s"\n' "$GITHUB_WORKSPACE"
+  exit 1
+}
 
 SHELLCHECK_DISABLE=0
 SHFMT_DISABLE=0
 SH_CHECKER_COMMENT=0
 CHECKBASHISMS_ENABLE=0
 
-if [ "${INPUT_SH_CHECKER_SHELLCHECK_DISABLE}" == "1" ] || [ "${INPUT_SH_CHECKER_SHELLCHECK_DISABLE}" == "true" ]; then
-	SHELLCHECK_DISABLE=1
+shopt -s nocasematch
+
+if [[ "${INPUT_SH_CHECKER_SHELLCHECK_DISABLE}" =~ ^(1|true|on|yes)$ ]]; then
+  SHELLCHECK_DISABLE=1
 fi
 
-if [ "${INPUT_SH_CHECKER_SHFMT_DISABLE}" == "1" ] || [ "${INPUT_SH_CHECKER_SHFMT_DISABLE}" == "true" ]; then
-	SHFMT_DISABLE=1
+if [[ "${INPUT_SH_CHECKER_SHFMT_DISABLE}" =~ ^(1|true|on|yes)$ ]]; then
+  SHFMT_DISABLE=1
 fi
 
-if [ "${INPUT_SH_CHECKER_COMMENT}" == "1" ] || [ "${INPUT_SH_CHECKER_COMMENT}" == "true" ]; then
-	SH_CHECKER_COMMENT=1
+if [[ "${INPUT_SH_CHECKER_COMMENT}" =~ ^(1|true|on|yes)$ ]]; then
+  SH_CHECKER_COMMENT=1
 fi
 
-if [ "$SHELLCHECK_DISABLE" == "1" ] && [ "$SHFMT_DISABLE" == "1" ]; then
-	echo "All checks are disabled, it's mean that \`sh_checker_shellcheck_disable\` and \`sh_checker_shfmt_disable\` are true"
+if [[ "${INPUT_SH_CHECKER_CHECKBASHISMS_ENABLE}" =~ ^(1|true|on|yes)$ ]]; then
+  CHECKBASHISMS_ENABLE=1
 fi
 
-if [ "${INPUT_SH_CHECKER_CHECKBASHISMS_ENABLE}" == "1" ] || [ "${INPUT_SH_CHECKER_CHECKBASHISMS_ENABLE}" == "true" ]; then
-	CHECKBASHISMS_ENABLE=1
+if ((SHELLCHECK_DISABLE == 1 && SHFMT_DISABLE == 1 && CHECKBASHISMS_ENABLE != 1)); then
+  echo "All checks are disabled: \`sh_checker_shellcheck_disable\` and \`sh_checker_shfmt_disable\` are both set to 1/true."
 fi
 
 # Internal functions
 _show_sh_files() {
-	local sh_files
-	sh_files="$(shfmt -f .)"
+  # using a global, as returning arrays in bash is ugly
+  # setting IFS to \n allows for spaces in file names:
+  IFS=$'\n' mapfile -t sh_files < <(shfmt -f .)
 
-	if [ -n "$INPUT_SH_CHECKER_EXCLUDE" ]; then
-		for i in $INPUT_SH_CHECKER_EXCLUDE; do
-			sh_files="$(echo "$sh_files" | grep -Ev "$i")"
-		done
-	fi
+  if [ -z "$INPUT_SH_CHECKER_EXCLUDE" ]; then
+    return 0
+  fi
 
-	echo "$sh_files"
+  OLDIFS="$IFS"
+  IFS=$' \t\n' read -d '' -ra excludes <<<"$INPUT_SH_CHECKER_EXCLUDE"
+  IFS=$'\n'
+  sh_all=("${sh_files[@]}")
+  sh_files=()
+  excluded=()
+  local sh exclude
+  for sh in "${sh_all[@]}"; do
+    for exclude in "${excludes[@]}"; do
+      grep -q -E "$exclude" <<<"$sh" || continue
+      excluded+=("$sh")
+      continue 2
+    done
+    sh_files+=("$sh")
+  done
+  if (("${#excluded[@]}" != 0)); then
+    printf 'The following %d shell script(s) will not be checked:\n' "${#excluded[@]}"
+    printf '"%s"\n' "${excluded[@]}"
+  fi
+  IFS="$OLDIFS"
 }
 
 _comment_on_github() {
-	local -r content="
+  local content
+  read -r -d '' content <<EOF
 #### \`sh-checker report\`
 
 To get the full details, please check in the [job]("https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID") output.
@@ -51,35 +75,42 @@ To get the full details, please check in the [job]("https://github.com/$GITHUB_R
 <summary>shellcheck errors</summary>
 
 \`\`\`
-${1:-No errors or shellcheck is disabled}
+$1
 \`\`\`
 </details>
 
 <details>
-<summary>shfmt erros</summary>
+<summary>shfmt errors</summary>
 
 \`\`\`
-${2:-No errors or shfmt is disabled}
+$2
 \`\`\`
 </details>
 
-"
-	local -r payload=$(echo "$content" | jq -R --slurp '{body: .}')
-	local -r comment_url=$(jq -r .pull_request.comments_url <"$GITHUB_EVENT_PATH")
+EOF
+  local -r payload=$(jq -R --slurp '{body: .}' <<<"$content")
+  local -r comment_url=$(jq -r .pull_request.comments_url <"$GITHUB_EVENT_PATH")
 
-	echo "Commenting on the pull request"
-	echo "$payload" | curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data @- "$comment_url" >/dev/null
+  echo "Commenting on the pull request"
+  curl -s -S -H "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/json" --data @- "$comment_url" <<<"$payload" >/dev/null
 }
 
-sh_files="$(_show_sh_files)"
+_show_sh_files
 
-test "$sh_files" || {
-	if ((ONLY_DIFF == 1)); then
-	  echo "No shell scripts were changed."
-	else
-	  echo "No shell scripts found in this repository. Make a sure that you did a checkout :)"
-	fi
-	exit 0
+((${#sh_files[@]} == 0)) && {
+  if ((ONLY_DIFF == 1)); then
+    echo "No shell scripts were changed."
+    exit 0
+  fi
+  if [ -n "$INPUT_SH_CHECKER_EXCLUDE" ]; then
+    if ((${#excluded[@]} == ${#sh_all[@]})); then
+      printf 'All %d shell script(s) have been excluded per your sh_checker_exclude setting:\n' "${#sh_all[@]}"
+      IFS=$' \t\n' printf '"%s"\n' "${excludes[@]}"
+      exit 0
+    fi
+  fi
+  echo "No shell scripts were found in this repository. Please check your settings."
+  exit 0
 }
 
 # Validate sh files
@@ -87,68 +118,74 @@ shellcheck_code=0
 checkbashisms_code=0
 shfmt_code=0
 exit_code=0
+shellcheck_error='shellcheck checking is disabled.'
+shfmt_error='shfmt checking is disabled.'
 
-if [ "$SHELLCHECK_DISABLE" != "1" ]; then
-	echo -e "Validating shell scripts files using shellcheck\n"
-	# shellcheck disable=SC2086
-	shellcheck_error=$( (shellcheck $sh_files) | while read -r x; do echo "$x"; done)
-	test -n "$shellcheck_error" && {
-		shellcheck_code="1"
-	}
+if ((SHELLCHECK_DISABLE != 1)); then
+  printf "Validating %d shell script(s) using 'shellcheck %s':\\n" "${#sh_files[@]}" "$SHELLCHECK_OPTS"
+  IFS=$' \t\n' read -d '' -ra args <<<"$SHELLCHECK_OPTS"
+  shellcheck_error="$(shellcheck "${args[@]}" "${sh_files[@]}" 2>&1)"
+  shellcheck_code=$?
+  if ((shellcheck_code == 0)); then
+    printf "'shellcheck %s' found no issues.\\n" "$SHELLCHECK_OPTS"
+  else
+    # .shellcheck returns 0-4: https://github.com/koalaman/shellcheck/blob/dff8f9492a153b4ad8ac7d085136ce532e8ea081/shellcheck.hs#L191
+    exit_code=$shellcheck_code
+    printf "\\n'shellcheck %s' returned error %s finding the following syntactical issues:\\n" "$SHELLCHECK_OPTS" "$shellcheck_code"
+    printf '%s' "$shellcheck_error"
+    printf '\n'
+    printf 'You can address these issues in three ways:\n'
+    printf '1. Manually correct the issue in the offending shell script;\n'
+    printf '2. Disable specific issues by adding the comment:\n'
+    printf '  # shellcheck disable=NNNN\n'
+    printf 'above the line that contains the issue, where NNNN is the error code;\n'
+    printf "3. Add '-e NNNN' to the SHELLCHECK_OPTS setting in your .yml action file.\\n"
+  fi
 fi
 
-if [ "$SHFMT_DISABLE" != "1" ]; then
-	echo -e "Validating shell scripts files using shfmt\n"
-	# shellcheck disable=SC2086
-	shfmt_error="$(eval shfmt $SHFMT_OPTS -d $sh_files)"
-	shfmt_code="$?"
+if ((SHFMT_DISABLE != 1)); then
+  printf "Validating %d shell script(s) using 'shfmt %s':\\n" "${#sh_files[@]}" "$SHFMT_OPTS"
+  IFS=$' \t\n' read -d '' -ra args <<<"$SHFMT_OPTS"
+  shfmt_error="$(shfmt "${args[@]}" "${sh_files[@]}" 2>&1)"
+  shfmt_code=$?
+  if ((shfmt_code == 0)); then
+    printf "'shfmt %s' found no issues.\\n" "$SHFMT_OPTS"
+  else
+    # shfmt returns 0 or 1: https://github.com/mvdan/sh/blob/dbbad59b44d586c0f3d044a3820c18c41b495e2a/cmd/shfmt/main.go#L72
+    ((exit_code |= 8))
+    printf "\\n'shfmt %s' returned error %d finding the following formatting issues:\\n" "$shfmt_code" "$SHFMT_OPTS"
+    printf '%s' "$shfmt_error"
+    printf '\n'
+    printf "You can use 'shfmt %s -w filename' to reformat each filename to meet shfmt's requirements.\\n" "$SHFMT_OPTS"
+  fi
 fi
 
-if [ "$CHECKBASHISMS_ENABLE" == "1" ]; then
-	echo -e "Validating 'bashisms' for shell scripts files using checkbashisms\n"
-	# shellcheck disable=SC2086
-	checkbashisms_error="$(checkbashisms $sh_files)"
-	checkbashisms_code="$?"
+if ((CHECKBASHISMS_ENABLE == 1)); then
+  printf 'Validating %d shell script(s) files using checkbashisms:\n' "${#sh_files[@]}"
+  checkbashisms "${sh_files[@]}"
+  checkbashisms_code=$?
+  if ((checkbashisms_code == 0)); then
+    printf 'checkbashisms found no issues.\n'
+  else
+    printf '\ncheckbashisms returned error %d finding the bashisms listed above.\n' "$checkbashisms_code"
+    if ((checkbashisms_code == 4)); then
+      # see https://github.com/duggan/shlint/blob/0fcd979319e3f37c2cd53ccea0b51e16fda710a1/lib/checkbashisms#L489
+      printf "Ignoring 'could not find any possible bashisms in bash script' issues\\n"
+    else
+      # checkbashisms returns 0-3: https://linux.die.net/man/1/checkbashisms
+      ((exit_code |= (checkbashisms_code << 4)))
+    fi
+  fi
 fi
 
-# Outputs
-if [ "$SHELLCHECK_DISABLE" != 1 ]; then
-	test "$shellcheck_code" != "0" && {
-		echo -e "$shellcheck_error"
-		echo -e "\nThe files above have some shellcheck issues\n"
-		exit_code=1
-	}
+if ((shellcheck_code != 0 || shfmt_code != 0)); then
+  if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && ((SH_CHECKER_COMMENT == 1)); then
+    _comment_on_github "$shellcheck_error" "$shfmt_error"
+  fi
 fi
 
-if [ "$SHFMT_DISABLE" != 1 ]; then
-	test "$shfmt_code" != "0" && {
-		echo -e "$shfmt_error"
-		echo -e "\nThe files above have some formatting problems, you can use \`shfmt -w\` to fix them\n"
-		exit_code=1
-	}
+if ((exit_code == 0)); then
+  printf 'No issues found in the %d shell script(s) scanned :)\n' "${#sh_files[@]}"
 fi
 
-if [ "$CHECKBASHISMS_ENABLE" == "1" ]; then
-	test "$checkbashisms_code" != "0" && {
-		echo -e "$checkbashisms_error"
-		echo -e "\nThe files above have some checkbashisms issues\n"
-		if ((checkbashisms_code != 4)); then
-		  exit_code=1
-		else
-		  # see https://github.com/duggan/shlint/blob/0fcd979319e3f37c2cd53ccea0b51e16fda710a1/lib/checkbashisms#L489
-		  echo -e "Ignoring 'could not find any possible bashisms in bash script' issues"
-		fi
-	}
-fi
-
-if [ "$shellcheck_code" != "0" ] || [ "$shfmt_code" != "0" ]; then
-	if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && [ "$SH_CHECKER_COMMENT" == "1" ]; then
-		_comment_on_github "$shellcheck_error" "$shfmt_error"
-	fi
-fi
-
-if [ "$shellcheck_code" == "0" ] && [ "$shfmt_code" == "0" ]; then
-	echo -e "All sh files found looks fine :)\n"
-fi
-
-exit "$exit_code"
+exit $exit_code

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -124,40 +124,52 @@ shfmt_error='shfmt checking is disabled.'
 if ((SHELLCHECK_DISABLE != 1)); then
   printf "Validating %d shell script(s) using 'shellcheck %s':\\n" "${#sh_files[@]}" "$SHELLCHECK_OPTS"
   IFS=$' \t\n' read -d '' -ra args <<<"$SHELLCHECK_OPTS"
-  shellcheck_error="$(shellcheck "${args[@]}" "${sh_files[@]}" 2>&1)"
+  shellcheck_output="$(shellcheck "${args[@]}" "${sh_files[@]}" 2>&1)"
   shellcheck_code=$?
   if ((shellcheck_code == 0)); then
-    printf "'shellcheck %s' found no issues.\\n" "$SHELLCHECK_OPTS"
+    printf -v shellcheck_error "'shellcheck %s' found no issues.\\n" "$SHELLCHECK_OPTS"
   else
     # .shellcheck returns 0-4: https://github.com/koalaman/shellcheck/blob/dff8f9492a153b4ad8ac7d085136ce532e8ea081/shellcheck.hs#L191
     exit_code=$shellcheck_code
-    printf "\\n'shellcheck %s' returned error %s finding the following syntactical issues:\\n" "$SHELLCHECK_OPTS" "$shellcheck_code"
-    printf '%s' "$shellcheck_error"
-    printf '\n'
-    printf 'You can address these issues in three ways:\n'
-    printf '1. Manually correct the issue in the offending shell script;\n'
-    printf '2. Disable specific issues by adding the comment:\n'
-    printf '  # shellcheck disable=NNNN\n'
-    printf 'above the line that contains the issue, where NNNN is the error code;\n'
-    printf "3. Add '-e NNNN' to the SHELLCHECK_OPTS setting in your .yml action file.\\n"
+    read -r -d '' shellcheck_error <<EOF
+
+'shellcheck $SHELLCHECK_OPTS' returned error $shellcheck_code finding the following syntactical issues:
+-----
+$shellcheck_output
+-----
+You can address these issues in on of three ways:\n'
+1. Manually correct the issue in the offending shell script;\n'
+2. Disable specific issues by adding the comment:\n'
+  # shellcheck disable=NNNN\n'
+above the line that contains the issue, where NNNN is the error code;\n'
+3. Add '-e NNNN' to the SHELLCHECK_OPTS setting in your .yml action file.
+
+EOF
   fi
+  printf '%s' "$shellcheck_error"
 fi
 
 if ((SHFMT_DISABLE != 1)); then
   printf "Validating %d shell script(s) using 'shfmt %s':\\n" "${#sh_files[@]}" "$SHFMT_OPTS"
   IFS=$' \t\n' read -d '' -ra args <<<"$SHFMT_OPTS"
-  shfmt_error="$(shfmt "${args[@]}" "${sh_files[@]}" 2>&1)"
+  shfmt_output="$(shfmt "${args[@]}" "${sh_files[@]}" 2>&1)"
   shfmt_code=$?
   if ((shfmt_code == 0)); then
-    printf "'shfmt %s' found no issues.\\n" "$SHFMT_OPTS"
+    printf -v shfmt_error "'shfmt %s' found no issues.\\n" "$SHFMT_OPTS"
   else
     # shfmt returns 0 or 1: https://github.com/mvdan/sh/blob/dbbad59b44d586c0f3d044a3820c18c41b495e2a/cmd/shfmt/main.go#L72
     ((exit_code |= 8))
-    printf "\\n'shfmt %s' returned error %d finding the following formatting issues:\\n" "$SHFMT_OPTS" "$shfmt_code" 
-    printf '%s' "$shfmt_error"
-    printf '\n'
-    printf "You can use 'shfmt %s -w filename' to reformat each filename to meet shfmt's requirements.\\n" "$SHFMT_OPTS"
+    read -r -d '' shfmt_error <<EOF
+
+'shfmt $SHFMT_OPTS' returned error $shfmt_code finding the following formatting issues:
+-----
+$shfmt_output
+-----
+You can use 'shfmt $SHFMT_OPTS -w filename' to reformat each filename to meet shfmt's requirements.
+
+EOF
   fi
+  printf '%s' "$shfmt_error"
 fi
 
 if ((CHECKBASHISMS_ENABLE == 1)); then


### PR DESCRIPTION
This PR adds the following features:
1. Adds support for filenames with spaces
2. Allows user to set flag with 1, true, on, or yes (case insensitively)
3. Lists files that are being excluded
4. Lists number of files that are being scanned
5. Replaces most echos with printf. See https://mywiki.wooledge.org/BashPitfalls?highlight=%28echo%29#echo_.24foo
6. Includes the shellcheck/shopt options in the log
7. Adds instructions on how to correct the issues found
8. Passes all shellcheck and shfmt's checks
9. Returns an exit code which binary ORs shellcheck's/shopt's/checkbashism's exit codes

I've tested everything **_including_** the SH_CHECKER_COMMENT logic.