### PR TITLE
feat: enable comments for pull_request_target event

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -202,7 +202,7 @@ if ((CHECKBASHISMS_ENABLE == 1)); then
 fi
 
 if ((shellcheck_code != 0 || shfmt_code != 0)); then
-	if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && ((SH_CHECKER_COMMENT == 1)); then
+	if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]] && ((SH_CHECKER_COMMENT == 1)); then
 		_comment_on_github "$shellcheck_error" "$shfmt_error"
 	fi
 fi


### PR DESCRIPTION
Currently, the action comments the pull requests only when it is triggered by `pull_request` event (See [L205](https://github.com/luizm/action-sh-checker/blob/master/entrypoint.sh#L205)).

However, according to the article [Keeping your GitHub Actions and workflows secure](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), the workflow has read-only permissions when it is triggered by `pull_request` event and it may fail and get the following errors.

```shell
Commenting on the pull request
{
  "message": "Resource not accessible by integration",
  "documentation_url": "https://docs.github.com/rest/reference/issues#create-an-issue-comment"
}
```

This pr enables the action to comment the pull requests when it is triggered by `pull_request_target` which has write permissions and fixes the above the errors.